### PR TITLE
fix: change download dir for raw coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: delete rawcoverage dir
         run: |
-          rmdir rawcoverage -rf
+          rm rawcoverage -rf
 
       - name: Upload lcov coverage file
         uses: actions/upload-artifact@v3.1.2
@@ -106,7 +106,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage/cobertura-coverage.xml # optional
           fail_ci_if_error: true # optional (default = false)
           verbose: true # optional   (default = false)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/download-artifact@v3.0.2
         with:
           name: test-runner coverage file
-          path: coverage/
+          path: rawcoverage/
       - name: Generate combined lcov coverage
         # TODO: exclude files with extension *.stories.tsx
         # and *.stories.js and *.stories.jsx from
@@ -83,7 +83,7 @@ jobs:
         # of nyc report. by default anything in ./tests
         # will be excluded by nyc report
         run: |
-          npx nyc report -t coverage --reporter cobertura
+          npx nyc report -t rawcoverage --reporter cobertura
 
       - name: Upload lcov coverage file
         uses: actions/upload-artifact@v3.1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,10 @@ jobs:
         run: |
           npx nyc report -t rawcoverage --reporter cobertura
 
+      - name: delete rawcoverage dir
+        run: |
+          rmdir rawcoverage -rf
+
       - name: Upload lcov coverage file
         uses: actions/upload-artifact@v3.1.2
         with:


### PR DESCRIPTION
need to do this otherwise codecov action was still trying to uplaod raw coverage file which was in the same folder and messing upload up from source branch of a PR, even though we explicitly specified the
cobertura coverage file generated by nyc report.